### PR TITLE
Revert "Validator fix"

### DIFF
--- a/exapaq.php
+++ b/exapaq.php
@@ -802,7 +802,6 @@ class Exapaq extends CarrierModule
 						$point['id_country']	 = $input['id_country'];
 
 						// Prepare cookie data with only necessary informations
-						$cookiedata = '';
 						$cookiedata[$point['relay_id']] = $point;
 
 						$point['distance']		 = number_format($item['DISTANCE'] / 1000, 2);


### PR DESCRIPTION
This reverts commit d2bd2cadc2c2b4bb824035bb835dcfb95b7cae65.

CRITICAL FIX !
This line emptied an array which is the front office cookie for relaypoint selection. It ended with HTTP 500 errors after validating order (hook newOrder).
