### PR TITLE
Replace deprecated jQuery function

### DIFF
--- a/views/templates/front/ps15/relais/dpdfrance_relais_opc.tpl
+++ b/views/templates/front/ps15/relais/dpdfrance_relais_opc.tpl
@@ -67,7 +67,7 @@ $(document).ready(function()
 /* Hack de la librairie Uniform pour PS 1.6 : supprime les div qui entourent les boutons radio */
 if (psVer >= 1.6)
 {
-	$(window).load(function(){
+	$(window).on('load', function(){
 		$(".dpdfrance_radiopr").each(function() {
 			radio = $(this).children('div').children('span').html();
 			label = $(this).children('label').prop('outerHTML');


### PR DESCRIPTION
With jQuery 3, `.load(` is deprectated.
Replaced with `.on('load',`
